### PR TITLE
feat(multiple): add overrides mixin to highlight-box and file-upload

### DIFF
--- a/projects/extensions/_index.scss
+++ b/projects/extensions/_index.scss
@@ -23,9 +23,9 @@ split-color, split-typography, split-density, split-base, split-overrides;
 @forward './tooltip/tooltip-theme' as tooltip-* show tooltip-theme,
 tooltip-color, tooltip-typography, tooltip-density, tooltip-base, tooltip-overrides;
 @forward './highlight-box/highlight-box-theme' as highlight-box-* show highlight-box-theme,
-highlight-box-color, highlight-box-typography, highlight-box-density, highlight-box-base;
+highlight-box-color, highlight-box-typography, highlight-box-density, highlight-box-base, highlight-box-overrides;
 @forward './file-upload/file-upload-theme' as file-upload-* show file-upload-theme,
-file-upload-color, file-upload-typography, file-upload-density, file-upload-base;
+file-upload-color, file-upload-typography, file-upload-density, file-upload-base, file-upload-overrides;
 
 @forward './core/theming/definition' show define-theme, define-colors, define-typography,
 define-density;

--- a/projects/extensions/file-upload/_file-upload-theme.scss
+++ b/projects/extensions/file-upload/_file-upload-theme.scss
@@ -11,8 +11,10 @@
   }
   @else {
     @include mat.private-current-selector-or-root() {
-      @include token-utils.create-token-values(tokens-mtx-file-upload.$prefix,
-        tokens-mtx-file-upload.get-unthemable-tokens());
+      @include token-utils.create-token-values(
+        tokens-mtx-file-upload.$prefix,
+        tokens-mtx-file-upload.get-unthemable-tokens()
+      );
     }
   }
 }
@@ -23,8 +25,10 @@
   }
   @else {
     @include mat.private-current-selector-or-root() {
-      @include token-utils.create-token-values(tokens-mtx-file-upload.$prefix,
-        tokens-mtx-file-upload.get-color-tokens($theme));
+      @include token-utils.create-token-values(
+        tokens-mtx-file-upload.$prefix,
+        tokens-mtx-file-upload.get-color-tokens($theme)
+      );
     }
   }
 }
@@ -33,7 +37,14 @@
   @if mat.get-theme-version($theme) == 1 {
     @include _theme-from-tokens(inspection.get-theme-tokens($theme, typography));
   }
-  @else {}
+  @else {
+    @include mat.private-current-selector-or-root() {
+      @include token-utils.create-token-values(
+        tokens-mtx-file-upload.$prefix,
+        tokens-mtx-file-upload.get-typography-tokens($theme)
+      );
+    }
+  }
 }
 
 @mixin density($theme) {
@@ -42,11 +53,28 @@
   }
   @else {
     @include mat.private-current-selector-or-root() {
-      @include token-utils.create-token-values(tokens-mtx-file-upload.$prefix,
-        tokens-mtx-file-upload.get-density-tokens($theme));
+      @include token-utils.create-token-values(
+        tokens-mtx-file-upload.$prefix,
+        tokens-mtx-file-upload.get-density-tokens($theme)
+      );
     }
   }
 }
+
+/// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.
+@function _define-overrides() {
+  @return (
+    (
+      namespace: tokens-mtx-file-upload.$prefix,
+      tokens: tokens-mtx-file-upload.get-token-slots(),
+    ),
+  );
+}
+
+@mixin overrides($tokens: ()) {
+  @include token-utils.batch-create-token-values($tokens, _define-overrides()...);
+}
+
 
 @mixin theme($theme) {
   @include mat.private-check-duplicate-theme-styles($theme, 'mtx-file-upload') {

--- a/projects/extensions/file-upload/file-upload.scss
+++ b/projects/extensions/file-upload/file-upload.scss
@@ -1,8 +1,6 @@
 @use '../core/tokens/token-utils';
 @use '../core/tokens/m2/mtx/file-upload' as tokens-mtx-file-upload;
 
-$_tokens: tokens-mtx-file-upload.$prefix, tokens-mtx-file-upload.get-token-slots();
-
 .mtx-file-upload {
   @include token-utils.use-tokens(tokens-mtx-file-upload.$prefix, tokens-mtx-file-upload.get-token-slots()) {
     $padding: token-utils.get-token-variable(container-vertical-padding);

--- a/projects/extensions/highlight-box/_highlight-box-theme.scss
+++ b/projects/extensions/highlight-box/_highlight-box-theme.scss
@@ -10,8 +10,10 @@
     @include _theme-from-tokens(inspection.get-theme-tokens($theme, base));
   } @else {
     @include mat.private-current-selector-or-root() {
-      @include token-utils.create-token-values(tokens-mtx-highlight-box.$prefix,
-        tokens-mtx-highlight-box.get-unthemable-tokens());
+      @include token-utils.create-token-values(
+        tokens-mtx-highlight-box.$prefix,
+        tokens-mtx-highlight-box.get-unthemable-tokens()
+      );
     }
   }
 }
@@ -21,8 +23,10 @@
     @include _theme-from-tokens(inspection.get-theme-tokens($theme, color));
   } @else {
     @include mat.private-current-selector-or-root() {
-      @include token-utils.create-token-values(tokens-mtx-highlight-box.$prefix,
-        tokens-mtx-highlight-box.get-color-tokens($theme));
+      @include token-utils.create-token-values(
+        tokens-mtx-highlight-box.$prefix,
+        tokens-mtx-highlight-box.get-color-tokens($theme)
+      );
     }
   }
 }
@@ -43,6 +47,20 @@
         tokens-mtx-highlight-box.get-density-tokens($theme));
     }
   }
+}
+
+/// Defines the tokens that will be available in the `overrides` mixin and for docs extraction.
+@function _define-overrides() {
+  @return (
+    (
+      namespace: tokens-mtx-highlight-box.$prefix,
+      tokens: tokens-mtx-highlight-box.get-token-slots(),
+    ),
+  );
+}
+
+@mixin overrides($tokens: ()) {
+  @include token-utils.batch-create-token-values($tokens, _define-overrides()...);
 }
 
 @mixin theme($theme) {

--- a/projects/extensions/highlight-box/highlight-box.scss
+++ b/projects/extensions/highlight-box/highlight-box.scss
@@ -1,8 +1,6 @@
 @use '../core/tokens/token-utils';
 @use '../core/tokens/m2/mtx/highlight-box' as tokens-mtx-highlight-box;
 
-$_tokens: tokens-mtx-highlight-box.$prefix, tokens-mtx-highlight-box.get-token-slots();
-
 .mtx-highlight-box {
   > div {
     border-left-style: solid;


### PR DESCRIPTION
Introduce token overrides mixins and related token definitions for
`highlight-box` and `file-upload` components.
This update allows greater customization and flexibility in theming
by utilizing the newly defined `overrides` structure.